### PR TITLE
9331 的 lede  的3.12 pppoe-server  不能正常读取

### DIFF
--- a/netkeeper4-use-pppoer-server/README.md
+++ b/netkeeper4-use-pppoer-server/README.md
@@ -7,6 +7,9 @@
 ### （一）路由器端
 配置完了再接wan口，不然会遇到Timeout waiting for PADO packets提示。要等一段时间才能拨号。原因不懂。
 #### 1.将netkeeper4文件夹下所有文件拷入openwrt的/root/目录。
+测试发现rp-pppoe-server_3.11版本不支持pap认证方式，3.12版本支持。
+
+3.11版本先使用[pppoe-server_3.11](./pppoe-server_3.11)目录下的脚本。同时，需要设置netkeeper接口的密码。等我研究研究做个根据版本自动识别的。
 #### 2.安装pppoe服务端
 安装自己路由器对应版本的ipk(这里以我的路由器为例)。
 
@@ -19,6 +22,7 @@ opkg install rp-pppoe-server
 方法二(路由器无法上网，自行下载对应ipk，这里以tengda-ac9为例)：
 ```sh
 opkg install rp-pppoe-common_3.12-1_arm_cortex-a9.ipk 
+opkg install rp-pppoe-common_3.12-1_arm_cortex-a9.ipk
 opkg install rp-pppoe-server_3.12-1_arm_cortex-a9.ipk
 ```
 #### 3.运行nk4conf.sh。
@@ -41,9 +45,13 @@ tenda-ac9 [lede17.01.0](https://downloads.lede-project.org/releases/17.01.0/targ
 
 newifi mini [PandoraBox 17.01](http://downloads.pandorabox.com.cn/pandorabox-16-10-stable/targets/ralink/mt7620/)固件
 
+hg255d/hc5661a PandoraBox固件 {Base on OpenWrt BARRIER BREAKER (14.09, r865)}
+
 地点：CQUPT
 
 ## 三、问题
 1.执行nk4conf.sh脚本后需要先重启路由器。不重启的话可以看到pppoe-server在进程里有，但是没有效果。
 
 2.有时会遇到ppp:Timeout waiting for PADO packets提示。要等一段时间才能拨号。
+
+3.pppoe-server版本区别，脚本通用性不强。

--- a/netkeeper4-use-pppoer-server/README.md
+++ b/netkeeper4-use-pppoer-server/README.md
@@ -21,7 +21,6 @@ opkg install rp-pppoe-server
 
 方法二(路由器无法上网，自行下载对应ipk，这里以tengda-ac9为例)：
 ```sh
-opkg install rp-pppoe-common_3.12-1_arm_cortex-a9.ipk 
 opkg install rp-pppoe-common_3.12-1_arm_cortex-a9.ipk
 opkg install rp-pppoe-server_3.12-1_arm_cortex-a9.ipk
 ```

--- a/netkeeper4-use-pppoer-server/pppoe-server_3.11/nk4
+++ b/netkeeper4-use-pppoer-server/pppoe-server_3.11/nk4
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=15
+
+start()
+
+{
+    sh /root/nk4.sh &
+    echo "netkeeper start"
+}
+

--- a/netkeeper4-use-pppoer-server/pppoe-server_3.11/nk4.sh
+++ b/netkeeper4-use-pppoer-server/pppoe-server_3.11/nk4.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#启动pppoe服务器。TODO：检测是否有pppoe服务器进程，再启动
+sleep 1
+pppoe-server -k -I br-lan
+
+#删掉之前的log，加快读取速度
+rm /tmp/pppoe.log
+
+while :
+do
+    username=$(grep "No CHAP secret found for authenticating" /tmp/pppoe.log  | tail -n 1 | cut -b 43-)
+
+    if [ "$username" != "$username_old" ]
+    then
+        ifdown netkeeper
+        uci set network.netkeeper.username="\r$username"
+        uci commit
+        ifup netkeeper
+        username_old="$username"
+        echo "new username $username"
+    fi
+#    echo "wait"
+    sleep 10
+
+done

--- a/netkeeper4-use-pppoer-server/pppoe-server_3.11/nk4conf.sh
+++ b/netkeeper4-use-pppoer-server/pppoe-server_3.11/nk4conf.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+#测试版本4.7.9.589，@cqupt
+
+#安装pppoe-server
+#opkg update
+#opkg install rp-pppoe-server
+
+#/etc/ppp/option 改 logfile /dev/null 为 logfile /tmp/pppoe.log
+sed -i "s/dev/tmp/" /etc/ppp/options
+sed -i "s/null/pppoe.log/" /etc/ppp/options
+#pppoe-server带的rp-pppoe.so无法加载，调用openwrt自带的rp-pppoe.so
+cp /etc/ppp/plugins/rp-pppoe.so /etc/ppp/plugins/rp-pppoe.so.bak
+cp /usr/lib/pppd/2.4.7/rp-pppoe.so /etc/ppp/plugins/rp-pppoe.so
+#/etc/ppp/pppoe-server-options 改require-pap为require-chap
+sed -i "s/require-pap/require-chap/" /etc/ppp/pppoe-server-options
+#/etc/ppp/chap-secrets添加一个用户(不添加无法运行)
+echo "test * test *">>/etc/ppp/chap-secrets
+
+#uci delete network.wan
+uci delete network.wan6
+uci commit network
+
+uci set network.netkeeper=interface
+uci set network.netkeeper.ifname=eth0.2
+uci set network.netkeeper.macaddr=aabbccddeeff
+uci set network.netkeeper.proto=pppoe
+#TODO:set pppoe password
+uci set network.netkeeper.username=username
+uci set network.netkeeper.password=password
+uci set network.netkeeper.metric='0'
+uci commit network
+#set firewall
+uci set firewall.@zone[1].network='wan netkeeper' 
+uci commit firewall
+/etc/init.d/firewall restart
+/etc/init.d/network reload
+/etc/init.d/network restart
+
+#使pppoe支持转义字符
+cp /lib/netifd/proto/ppp.sh /lib/netifd/proto/ppp.sh_bak
+sed -i '/proto_run_command/i username=`echo -e "$username"`' /lib/netifd/proto/ppp.sh
+sed -i '/proto_run_command/i password=`echo -e "$password"`' /lib/netifd/proto/ppp.sh
+
+#设置启动脚本
+cp /root/nk4 /etc/init.d/nk4
+chmod +x /etc/init.d/nk4
+/etc/init.d/nk4 enable
+


### PR DESCRIPTION
Using interface ppp0
Connect: ppp0 <--> br-lan
no PAP secret found for 123123
PAP peer authentication failed for 123123
Connection terminated.
Plugin /etc/ppp/plugins/rp-pppoe.so loaded.
RP-PPPoE plugin version 3.8p compiled against pppd 2.4.7