### PR TITLE
开机的时候自动拨号

### DIFF
--- a/netkeeper4-use-pppoer-server/nk4.sh
+++ b/netkeeper4-use-pppoer-server/nk4.sh
@@ -10,6 +10,11 @@ pppoe-server -k -I br-lan
 #clear logs
 cat /dev/null > /tmp/pppoe.log
 
+sleep 15 # wait 15s for reboot, or it will throw error for 'you have accessed in'
+logger -t nk4 "try to login at power on"
+ifdown netkeeper
+ifup netkeeper
+
 while :
 do
     #read the last username in pppoe.log


### PR DESCRIPTION
我的发现：前一天拨号时生成的账号，在之后几天依然可以用来拨号
也就是说可以在每次开机的时候直接先用之前生成账号拨
（仅重邮）