### PR TITLE
Changed the way to obtain the device name of WAN

### DIFF
--- a/netkeeper4-use-pppoer-server/nk4conf.sh
+++ b/netkeeper4-use-pppoer-server/nk4conf.sh
@@ -20,7 +20,7 @@ uci delete network.wan6
 uci commit network
 
 uci set network.netkeeper=interface
-uci set network.netkeeper.ifname=$(uci show network.wan.ifname | awk -F "'" '{print $2}')
+uci set network.netkeeper.ifname=$(uci show network.wan.device | awk -F "'" '{print $2}')
 uci set network.netkeeper.proto=pppoe
 uci set network.netkeeper.username=username
 uci set network.netkeeper.password=password


### PR DESCRIPTION
In recent versions of OpenWrt, the "device" property has taken the place of "ifname" which no longer exists. Running this script made for older versions in newer ones will result in the "netkeeper" interface unattached to any device.